### PR TITLE
feature: Remove code that disallows immediate ticker resubscription

### DIFF
--- a/docs/src/SubscriptionPlayground.tsx
+++ b/docs/src/SubscriptionPlayground.tsx
@@ -143,6 +143,7 @@ function Playground() {
         language="js"
         code={`() => {
   const [play, setPlay] = React.useState(false)
+  const [forceUpdate, setForceUpdate] = React.useState(0)
   const [events, setEvents] = React.useState([])
   const handleEvent = React.useCallback((event) => {
     setEvents((prevState) => [...prevState, event])
@@ -165,13 +166,18 @@ function Playground() {
       }
     }
     return () => unsubscribe && unsubscribe()
-  }, [play])
+  }, [play, forceUpdate])
 
   return (
     <>
       <Button variant="outlined" onClick={() => setPlay(!play)}>
         {play ? 'Stop' : 'Start'}
       </Button>
+      {play && (
+        <Button variant="outlined" onClick={() => setForceUpdate({})}>
+          Resubscribe
+        </Button>
+      )}
       <DataViewer play={play} events={events} />
     </>
   )

--- a/src/feed.test.ts
+++ b/src/feed.test.ts
@@ -165,7 +165,7 @@ describe('Feed - subscriptions', () => {
     expect(publishSecondTime).toBeCalledTimes(1)
     expect(publishSecondTime).toBeCalledWith({
       add: { [eventType]: symbolsSet2 },
-      remove: { [eventType]: ['1', '4'] },
+      remove: { [eventType]: symbolsSet1 },
     })
   })
 

--- a/src/subscriptions.ts
+++ b/src/subscriptions.ts
@@ -153,10 +153,26 @@ export class Subscriptions {
         // Add listeners
         this.subscriptions[eventType][eventSymbol].listeners.push(onChange /* FIXME */ as any)
 
-        // Delete from remove queue
-        if (this.queue.remove[eventType]) {
-          delete this.queue.remove[eventType][eventSymbol]
-        }
+        /**
+         * When backend receives message with `add` for the first time for symbol subscription, it immediately
+         * pushes last ticker's value to a subscriber. The same is relevant for situation when backend receives
+         * message with `remove`, and then, some ticks later, it receives another message with `add`.
+         *
+         * If `add` and `remove` are sent in one message, backend treats them in the following order: first remove
+         * subscription, then add it back and push last value of ticker into it.
+         * 
+         * When code below is not commented out, it deletes `remove` from message in situation
+         * when `add` and `remove` occur in one tick. This makes backend treat message as "update subscription",
+         * which effectively means "do nothing". New subscriber won't receive last value of ticker because subscription
+         * already exists, and will only receive the next ticker update.
+         * 
+         * This sometimes leads to cases when ticker appears empty for new subscribers of a rarely updated symbols.
+         * (Related issue: EN-4718)
+         */
+
+        // if (this.queue.remove[eventType]) {
+        //   delete this.queue.remove[eventType][eventSymbol]
+        // }
 
         this.addQueue(eventType, eventSymbol)
       })


### PR DESCRIPTION
Deletes code that checks if there's an entry for current symbol in `remove` set of pending message. This allows for immediate resubscription (i.e. unsubscribe -> subscribe -> receive last event in ticker).