### PR TITLE
bugfix: Reconnect after network loss logic.

### DIFF
--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -17,6 +17,7 @@ type DataChangeHandler = (message: IncomingData, timeSeries: boolean) => void
 export class Endpoint {
   cometd: CometD | null = null
   authToken: string | null = null
+  connectionAlive: boolean = false
 
   handlers: {
     onStateChange?: StateChangeHandler
@@ -32,17 +33,18 @@ export class Endpoint {
   }
 
   private updateConnectedState(connected: boolean) {
-    if (this.isConnected() !== connected) {
+    if (this.connectionAlive !== connected) {
+      this.connectionAlive = connected
       this.handlers?.onStateChange({ connected })
     }
   }
 
   private onMetaUpdate = (message: Message) => {
     if (!this.isConnected()) {
-      this.updateConnectedState(false)
-    } else {
-      this.updateConnectedState(message.successful)
+      return this.updateConnectedState(false)
     }
+
+    this.updateConnectedState(message.successful)
   }
 
   private onMetaUnsuccessful = () => {

--- a/src/subscriptions.ts
+++ b/src/subscriptions.ts
@@ -96,6 +96,7 @@ export class Subscriptions {
       queue.remove = {}
       queue.addTimeSeries = this.timeSeriesSubscriptions
       queue.removeTimeSeries = {}
+      queue.reset = false
     }
 
     if (!isEmptySet(queue.add)) {


### PR DESCRIPTION
Until now, there was no check of current connection state: whether it's alive or not. Only inner state of CometD transport connection was checked on meta update (i.e. `feed.isDisconnected()`), and actually it was always `true`, because WebSocket connection never gets closed by itself, unless client closes it directly. This PR adds `connectionAlive` boolean state, which is checked against and updated when network connection changes. 